### PR TITLE
:bug: Fix a Machine -> KubeadmConfig mapping bug

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -127,6 +127,16 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	// Lookup the cluster the machine is associated with
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machine.ObjectMeta)
 	if err != nil {
+		if errors.Cause(err) == util.ErrNoCluster {
+			log.Info("Machine does not belong to a cluster yet, waiting until its part of a cluster")
+			return ctrl.Result{}, nil
+		}
+
+		if apierrors.IsNotFound(err) {
+			log.Info("Cluster does not exist yet , waiting until it is created")
+			return ctrl.Result{}, nil
+		}
+
 		log.Error(err, "could not get cluster by machine metadata")
 		return ctrl.Result{}, err
 	}

--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -127,15 +127,6 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	// Lookup the cluster the machine is associated with
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machine.ObjectMeta)
 	if err != nil {
-		if errors.Cause(err) == util.ErrNoCluster {
-			log.Info("Machine does not belong to a cluster yet, waiting until its part of a cluster")
-			return ctrl.Result{}, nil
-		}
-
-		if apierrors.IsNotFound(err) {
-			log.Info("Cluster does not exist yet , waiting until it is created")
-			return ctrl.Result{}, nil
-		}
 
 		log.Error(err, "could not get cluster by machine metadata")
 		return ctrl.Result{}, err

--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -73,7 +73,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &clusterv1.Machine{}},
 			&handler.EnqueueRequestsFromMapFunc{
-				ToRequests: util.MachineToInfrastructureMapFunc(bootstrapv1.GroupVersion.WithKind("KubeadmConfig")),
+				ToRequests: handler.ToRequestsFunc(r.MachineToBootstrapMapFunc),
 			},
 		).
 		Watches(
@@ -127,16 +127,6 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	// Lookup the cluster the machine is associated with
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machine.ObjectMeta)
 	if err != nil {
-		if errors.Cause(err) == util.ErrNoCluster {
-			log.Info("Machine does not belong to a cluster yet, waiting until its part of a cluster")
-			return ctrl.Result{}, nil
-		}
-
-		if apierrors.IsNotFound(err) {
-			log.Info("Cluster does not exist yet , waiting until it is created")
-			return ctrl.Result{}, nil
-		}
-
 		log.Error(err, "could not get cluster by machine metadata")
 		return ctrl.Result{}, err
 	}
@@ -397,6 +387,22 @@ func (r *KubeadmConfigReconciler) ClusterToKubeadmConfigs(o handler.MapObject) [
 		}
 	}
 
+	return result
+}
+
+// MachineToKubeadmConfig is a handler.ToRequestsFunc to be used to enqeue
+// request for reconciliation of KubeadmConfig.
+func (r *KubeadmConfigReconciler) MachineToBootstrapMapFunc(o handler.MapObject) []ctrl.Request {
+	result := []ctrl.Request{}
+
+	m, ok := o.Object.(*clusterv1.Machine)
+	if !ok {
+		return nil
+	}
+	if m.Spec.Bootstrap.ConfigRef != nil && m.Spec.Bootstrap.ConfigRef.GroupVersionKind() == bootstrapv1.GroupVersion.WithKind("KubeadmConfig") {
+		name := client.ObjectKey{Namespace: m.Namespace, Name: m.Spec.Bootstrap.ConfigRef.Name}
+		result = append(result, ctrl.Request{NamespacedName: name})
+	}
 	return result
 }
 


### PR DESCRIPTION

What this PR does / why we need it:

Corrects the mapping function used for triggering Kubeadmconfig reconcile in case Machine is modified

Fixes https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/issues/227
